### PR TITLE
Fix task type for PR events

### DIFF
--- a/event_router.py
+++ b/event_router.py
@@ -72,7 +72,8 @@ def handle_pull_request(payload):
     if action in ['opened', 'synchronize']:
         task_data = {
             'task_id': f"pr_{pr['number']}_{int(datetime.now().timestamp())}",
-            'type': 'pr_review',
+            # Worker expects tasks of type 'open_pr'
+            'type': 'open_pr',
             'action': action,
             'repo': repo,
             'pr_number': str(pr['number']),


### PR DESCRIPTION
## Summary
- route pull request events using `'open_pr'` type so they work with the worker

## Testing
- `python3 -m py_compile event_router.py`
- `python3 -m unittest discover` *(fails: `No module named 'redis'`)*

------
https://chatgpt.com/codex/tasks/task_e_6866394cab60833097976d1c5e8f6147